### PR TITLE
Static plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ testing.ipynb
 docs/build/*
 docs/html/*
 dev_venv/*
+*.ipynb

--- a/cartographi/__init__.py
+++ b/cartographi/__init__.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 __version__ = "1.1.3"
 __description__ = "CartograPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"

--- a/cartographi/__init__.py
+++ b/cartographi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.1.2"
 __description__ = "CartograPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, Jonathan Smith, Maria Fox, James Byrne, Michael Thorne"

--- a/cartographi/__init__.py
+++ b/cartographi/__init__.py
@@ -1,5 +1,5 @@
 <<<<<<< HEAD
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __description__ = "CartograPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Samuel Hall, George Coombs, Harrison Abbot, Ayat Fekry, Jonathan Smith, Maria Fox, James Byrne, Michael Thorne"

--- a/cartographi/cli.py
+++ b/cartographi/cli.py
@@ -108,7 +108,7 @@ def create_mesh_cli():
 def export_mesh_cli():
     """
         CLI entry point for exporting a mesh to standard formats.
-        Currently supported formats are JSON, GEOJSON, TIF
+        Currently supported formats are JSON, GEOJSON, TIF, PNG
     """
     # Default, used only by the Mesh Builder and CartograPhi
     args = get_args("mesh.json", 
@@ -124,6 +124,12 @@ def export_mesh_cli():
         
     elif args.format.upper() == "TIF":
         args = get_args("mesh.tif", 
+                    config_arg = False, 
+                    mesh_arg = True, 
+                    format_arg = True)
+
+    elif args.format.upper() == "PNG":
+        args = get_args("mesh.png", 
                     config_arg = False, 
                     mesh_arg = True, 
                     format_arg = True)

--- a/cartographi/mesh_generation/environment_mesh.py
+++ b/cartographi/mesh_generation/environment_mesh.py
@@ -131,6 +131,24 @@ class EnvironmentMesh:
 
         return json.loads(json.dumps(output, indent=4))
     
+    def to_png(self, params_file, path):
+        from cartographi.mesh_plotting.mesh_plotter import MeshPlotter
+
+        mesh_json = self.to_json()
+        plotter = MeshPlotter(mesh_json)
+
+        if (params_file != None):
+            with open(params_file) as f:
+                data = f.read()
+                format_params = json.loads(data)
+
+        for item in format_params['cmaps']:
+            plotter.plot_cmap(item['data_name'], item['cmap'])
+        for item in format_params['bools']:
+            plotter.plot_bool(item['data_name'], item['colour'])
+            
+        plotter.save(path)
+
 
     def to_geojson(self, params_file = None):
         """
@@ -475,6 +493,9 @@ class EnvironmentMesh:
         elif format.upper() == "GEOJSON":
             with open(path, 'w') as path:
                 json.dump(self.to_geojson(format_params), path, indent=4)
+
+        elif format.upper() == "PNG":
+            self.to_png(format_params, path)
 
         else:
             logging.warning(f"Cannot save mesh in a {format} format")

--- a/cartographi/mesh_generation/environment_mesh.py
+++ b/cartographi/mesh_generation/environment_mesh.py
@@ -132,6 +132,12 @@ class EnvironmentMesh:
         return json.loads(json.dumps(output, indent=4))
     
     def to_png(self, params_file, path):
+        """
+            exports a mesh and saves to a png file
+            Args:
+                params_file: A format configuration files as a json object
+                path: The path to save the png file
+        """
         from cartographi.mesh_plotting.mesh_plotter import MeshPlotter
 
         mesh_json = self.to_json()

--- a/cartographi/mesh_plotting/mesh_plotter.py
+++ b/cartographi/mesh_plotting/mesh_plotter.py
@@ -67,4 +67,9 @@ class MeshPlotter:
             self.plot.add_geometries([polygon], ccrs.PlateCarree(), facecolor=cmap(normalized_value), alpha=1.0, edgecolor='darkslategrey')
    
     def save(self, filename):
+        """
+        Saves the plot to a file.
+        Args:
+            filename (str): The name of the file to save the plot to.
+        """
         plt.savefig(filename)

--- a/cartographi/mesh_plotting/mesh_plotter.py
+++ b/cartographi/mesh_plotting/mesh_plotter.py
@@ -1,0 +1,70 @@
+import cartopy
+import cartopy.crs as ccrs
+import shapely
+from shapely.geometry import Point, Polygon
+import matplotlib
+from matplotlib import cm
+import matplotlib.pyplot as plt
+import pandas as pd
+
+class MeshPlotter:
+    """
+        Object for plotting mesh json files using matplotlib and cartopy.
+    """
+  
+    def __init__(self, mesh_json, figscale=10):
+
+        self.mesh_json = mesh_json
+        self.mesh_df = pd.DataFrame(self.mesh_json['cellboxes'])
+
+        self.lat_min = mesh_json['config']['mesh_info']['region']['lat_min']
+        self.lat_max = mesh_json['config']['mesh_info']['region']['lat_max']
+        self.long_min = mesh_json['config']['mesh_info']['region']['long_min']
+        self.long_max = mesh_json['config']['mesh_info']['region']['long_max']
+
+        self.figscale = figscale
+        
+        self.aspect_ratio = (self.long_max - self.long_min) / (self.lat_max - self.lat_min)
+
+        self.fig = plt.figure(figsize=(self.figscale * self.aspect_ratio, self.figscale))
+
+        self.plot = plt.axes(projection=ccrs.PlateCarree())
+        self.plot.set_extent([self.long_min, self.long_max, self.lat_min, self.lat_max])
+
+
+    def plot_bool(self, value_name, colour):
+        """
+        Plots boolean values from the mesh json file.
+        Args:
+            value_name (str): The name of the boolean value to plot.
+            colour (str): The colour to plot the value in.
+        """
+        for cellbox in self.mesh_json['cellboxes']:
+            polygon = shapely.wkt.loads(cellbox['geometry'])
+            if cellbox[value_name] == True:
+                self.plot.add_geometries([polygon], ccrs.PlateCarree(), facecolor=colour, alpha=1.0, edgecolor='darkslategrey')
+
+    def plot_cmap(self, value_name, colourmap):
+        """
+        Plots colourmap values from the mesh json file.
+        Args:
+            value_name (str): The name of the colourmap value to plot.
+            colourmap (str): The colourmap to plot the value in.
+        """
+        
+        # get min and max values for normalisation
+        value_min = self.mesh_df[value_name].min()
+        value_max = self.mesh_df[value_name].max()
+        value_diff = value_max - value_min
+
+        # get Colourmap from matplotlib
+        cmap = matplotlib.colormaps[colourmap]
+        for cellbox in self.mesh_json['cellboxes']:
+
+            # normalise value
+            normalized_value = (cellbox[value_name] - value_min) / value_diff
+            polygon = shapely.wkt.loads(cellbox['geometry'])
+            self.plot.add_geometries([polygon], ccrs.PlateCarree(), facecolor=cmap(normalized_value), alpha=1.0, edgecolor='darkslategrey')
+   
+    def save(self, filename):
+        plt.savefig(filename)

--- a/docs/source/sections/Plotting/mesh_plotting.rst
+++ b/docs/source/sections/Plotting/mesh_plotting.rst
@@ -1,0 +1,7 @@
+############################
+Mesh Plotting
+############################
+
+.. automodule:: cartographi.mesh_plotting.mesh_plotter
+    :special-members: __init__
+    :members:

--- a/examples/export_configs/PNG/plotting_conf.json
+++ b/examples/export_configs/PNG/plotting_conf.json
@@ -1,0 +1,18 @@
+{
+    "bools": [
+        {
+            "data_name": "ext_ice",
+            "colour": "red"
+        },
+        {
+            "data_name": "land",
+            "colour": "grey"
+        }
+    ],
+    "cmaps": [
+        {
+            "data_name": "SIC",
+            "cmap": "BuPu"
+        }
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn
 scipy
 tqdm
 xarray
+cartopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ scipy
 tqdm
 xarray
 cartopy
+rasterio
+


### PR DESCRIPTION
# CartograPhi Pull Request Template

Date: 04/10/2023
Version Number: 1.1.2 -> 1.1.3
 
## Description of change
Adding ability to export meshes to PNG via matplotlib/ cartopy static plotting.

## Fixes # (issue)
#172 - Static Plotting

# Testing
To ensure that the functionality of the CartograPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy

[test_mesh.txt](https://github.com/antarctica/CartograPhi/files/12801523/test_mesh.txt)

- [ ] My changes result in all required regression tests passing without updating test files.  
  
> *list which files have been altered and include a pytest.txt file for each of
> the tests required to be run*
>
> The files which have been changed during this PR can be listed using the command

cartographi/__init__.py
cartographi/cli.py
cartographi/mesh_generation/environment_mesh.py
cartographi/mesh_plotting/mesh_plotter.py
docs/source/sections/Plotting/mesh_plotting.rst
examples/export_configs/PNG/plotting_conf.json
requirements.txt


- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
